### PR TITLE
Bug fixes to nifi.py

### DIFF
--- a/nifi_TA_monitoring/bin/nifi.py
+++ b/nifi_TA_monitoring/bin/nifi.py
@@ -2,7 +2,7 @@ import sys
 import os
 import requests
 import urllib3
-#import dotenv
+import dotenv
 import xml.etree.ElementTree as ElementTree
 import uuid
 
@@ -11,8 +11,8 @@ import splunklib.client as client
 from splunklib.modularinput import EventWriter, Argument, Scheme, Event, Script
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-#dotenv_file = dotenv.find_dotenv()
-#dotenv.load_dotenv(dotenv_file)
+dotenv_file = dotenv.find_dotenv()
+dotenv.load_dotenv(dotenv_file)
 
 
 class NiFiScript(Script):
@@ -305,7 +305,7 @@ class NiFiScript(Script):
                 if response.status_code == 401:
                     EventWriter.log(ew, EventWriter.ERROR, '{} Error HTTP request - status_code: {}, reason: {}, url: {}'.format(self.pid, response.status_code, response.reason, url))
                     token = self.__get_token(ew, base_url, username, password)
-                    #dotenv.set_key(dotenv_file, input_name, token)
+                    dotenv.set_key(dotenv_file, input_name, token)
                     headers = {'Content-Type': 'application/json', 'Accept':'application/json', 'Authorization': 'Bearer {}'.format(token)}
                     response = requests.get(url, **req_args)
                     if response.status_code >= 400:

--- a/nifi_TA_monitoring/bin/nifi.py
+++ b/nifi_TA_monitoring/bin/nifi.py
@@ -354,7 +354,6 @@ class NiFiScript(Script):
             kwargs = dict((k, input_item[k]) for k in ['username', 
                                                         'api_url',
                                                         'auth_type',
-                                                        'password',
                                                         'interval',
                                                         'endpoint_system_diagnostics',
                                                         'endpoint_flow_status',
@@ -362,6 +361,7 @@ class NiFiScript(Script):
                                                         'endpoint_processors_history',
                                                         'endpoint_process_groups_history'
                                                         ] if k in input_item)
+            kwargs['password'] = self.mask
             item.update(**kwargs).refresh()
            
         except Exception as e:

--- a/nifi_TA_monitoring/default/app.conf
+++ b/nifi_TA_monitoring/default/app.conf
@@ -1,6 +1,6 @@
 [launcher]
 author = Kudaw
-version = 1.2.0
+version = 1.2.1
 description = Add-on to normalize fields from NiFi Reporting Tasks and Metrics
 
 [ui]


### PR DESCRIPTION
Fixed an issue causing the script to always run the encrypt and mask functions, as the password property got rewritten with the same value. Modified the kwargs password key to contain self.mask to fix this issue.

After authenticating with NiFi, the auth token never got stored in the class, or as an os environment variable. Commented in the dotenv code to fix the authentication issue, and allow for persistence between runs.